### PR TITLE
Oakveil 1.1 updates

### DIFF
--- a/DataStore.cs
+++ b/DataStore.cs
@@ -247,11 +247,13 @@ public class DataStore
 			_ => null
 		};
 
-		ServerChatUtils.SendSystemMessageToAllClients(VWorld.Server.EntityManager, Markup.Prefix + message);
+		FixedString512Bytes systemLostStreakMessage = Markup.Prefix + message;
+		ServerChatUtils.SendSystemMessageToAllClients(VWorld.Server.EntityManager, ref systemLostStreakMessage);
 
 		if (!string.IsNullOrEmpty(killMsg) && Settings.AnnounceKillstreak)
 		{
-			ServerChatUtils.SendSystemMessageToAllClients(VWorld.Server.EntityManager, Markup.Prefix + killMsg);
+			FixedString512Bytes systemKillMessage = Markup.Prefix + killMsg;
+			ServerChatUtils.SendSystemMessageToAllClients(VWorld.Server.EntityManager, ref systemKillMessage);
 		}
 	}
 

--- a/Killfeed.csproj
+++ b/Killfeed.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="BepInEx.Unity.IL2CPP" Version="6.0.0-be.691" IncludeAssets="compile" />
     <PackageReference Include="BepInEx.Core" Version="6.0.0-be.691" IncludeAssets="compile" />
     <PackageReference Include="BepInEx.PluginInfoProps" Version="2.*" />
-    <PackageReference Include="VRising.Unhollowed.Client" Version="1.0.*" />
+    <PackageReference Include="VRising.Unhollowed.Client" Version="1.1.*" />
     <PackageReference Include="VRising.VampireCommandFramework" Version="0.9.*" />
     <PackageReference Include="VRising.Bloodstone" Version="0.2.*" />
   </ItemGroup>


### PR DESCRIPTION
This PR updates the system messages to take the new FixedString512Bytes type. 

Built and tested using:
bep 1.733.2 RC2): https://github.com/decaprime/VRising-Modding/releases/tag/1.733.2
vfc v0.10.0: pre release https://github.com/decaprime/VampireCommandFramework/releases/tag/v0.10.0
bloodstone: https://github.com/mfoltz/Bloodstone

Understandable if you want to wait on this because deps are not stable yet but I thought I would make PR incase it was helpful

cheers